### PR TITLE
chore: add login to chainguard registry

### DIFF
--- a/.github/workflows/common-docker.yml
+++ b/.github/workflows/common-docker.yml
@@ -10,10 +10,14 @@ on:
       AWS_SECRET_KEY_S3_USER:
         required: true
       CGR_USERNAME:
-        required: true
+        required: false
       CGR_PASSWORD:
-        required: true
+        required: false
     inputs:
+      use-cgr-secrets:
+        type: boolean
+        required: false
+        default: false
       ref:
         type: string
         required: false
@@ -214,6 +218,7 @@ jobs:
 
       - name: Login to Chainguard Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        if: ${{ inputs.use-cgr-secrets }}
         with:
           registry: cgr.dev
           username: ${{ secrets.CGR_USERNAME }}


### PR DESCRIPTION
Add Chainguard credentials in secrets inputs, and login to Chainguard registry so we can use versioned Chainguard images

`fhevm` PR to use the updated `common-docker` workflow: https://github.com/zama-ai/fhevm/pull/734