### PR TITLE
fix: use correct commit hash in PR

### DIFF
--- a/.github/workflows/common-docker.yml
+++ b/.github/workflows/common-docker.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: Set Docker Tag
         id: set-tag
+        env:
+          COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           if [[ -n "${{ inputs.image-tag }}" ]]; then
             echo "tag=${{ inputs.image-tag }}" >> "$GITHUB_OUTPUT"
@@ -89,9 +91,9 @@ jobs:
             echo "VERSION: $VERSION"
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "tag=nightly-$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_OUTPUT"
+            echo "tag=nightly-$(git rev-parse --short "$COMMIT_HASH")" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_OUTPUT"
+            echo "tag=$(git rev-parse --short "$COMMIT_HASH")" >> "$GITHUB_OUTPUT"
           fi
 
   build-and-push-docker:


### PR DESCRIPTION
Motivation for this PR is that when docker images are built **in a PR** (not in main branch), the commit hash used to publish the images is incorrect.

See this [PR](https://github.com/zama-ai/fhevm/pull/736) for instance, commit hash was `f0f1b3d`, but images are published under `b92ab02` (proof [here](https://github.com/zama-ai/fhevm/actions/runs/16992187351/job/48174096442?pr=736)).

This is an expected behavior from GitHub, see https://github.com/orgs/community/discussions/26325

Example of PR using this fixed workflow, which publish the images under the correct hash: https://github.com/zama-ai/fhevm/pull/738