### PR TITLE
fix: make rust version optional for docker build

### DIFF
--- a/.github/workflows/common-docker.yml
+++ b/.github/workflows/common-docker.yml
@@ -153,16 +153,13 @@ jobs:
       - name: Get Rust version
         run: |
           if [[ -n "${{ inputs.rust-version }}" ]]; then
-            version="${{ inputs.rust-version }}"
+            echo "RUST_IMAGE_VERSION=${{ inputs.rust-version }}" >> "$GITHUB_ENV"
           else
             if [[ -f "${{ inputs.rust-toolchain-file-path }}" ]]; then
               version=$(grep 'channel' "${{ inputs.rust-toolchain-file-path }}" | awk -F' = ' '{print $2}' | tr -d '"')
-            else
-              echo "You must provide either 'rust-version' or 'rust-toolchain-file-path' as input!"
-              exit 1
+              echo "RUST_IMAGE_VERSION=$version" >> "$GITHUB_ENV"
             fi
           fi
-          echo "RUST_IMAGE_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0


### PR DESCRIPTION
Ref https://github.com/zama-ai/ci-templates/pull/23
Ref https://github.com/zama-ai/ci-templates/issues/22

Make the use of either `rust-version` or `rust-toolchain-file-path` optional, so the `common-docker` workflow can be used more intuitively to build docker images not using Rust (`gateway-contracts`, `host-contracts`, `test-suite`...) 