### PR TITLE
chore: pass through extra Docker build args

### DIFF
--- a/.github/workflows/common-docker.yml
+++ b/.github/workflows/common-docker.yml
@@ -52,6 +52,10 @@ on:
         type: string
         default: "Dockerfile"
         required: false
+      extra-build-args:
+        type: string
+        default: ""
+        required: false
       cache-from:
         type: string
         required: false
@@ -226,6 +230,7 @@ jobs:
             SCCACHE_BUCKET=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
             SCCACHE_REGION=${{ env.RUNS_ON_AWS_REGION }}
             SCCACHE_S3_PREFIX=sccache/${{ github.repository }}/${{ inputs.app-cache-dir }}/${{ matrix.platform-tag }}
+            ${{ inputs.extra-build-args }}
           context: ${{ inputs.docker-context }}
           secrets: |
             BLOCKCHAIN_ACTIONS_TOKEN=${{ secrets.BLOCKCHAIN_ACTIONS_TOKEN }}


### PR DESCRIPTION
I'm making another attempt to fix KMS image builds in https://github.com/zama-ai/kms/pull/609, so `kms-server` is actually built with different flags for "prod" and "dev" images, and that requires being able to pass Docker build flags in the `common-docker.yml` template. This PR does just that.