### PR TITLE
ci: opt-in arm64 image publishing (build-arm input, default off)

### DIFF
--- a/.github/workflows/common-docker.yml
+++ b/.github/workflows/common-docker.yml
@@ -44,6 +44,15 @@ on:
         type: string
         required: false
         default: "ubuntu-latest"
+      runs-on-arm:
+        type: string
+        required: false
+        default: "large_ubuntu_16_arm"
+      build-arm:
+        description: "Also build and publish linux/arm64 (opt-in per image; default keeps builds amd64-only)"
+        type: boolean
+        required: false
+        default: false
       docker-file:
         type: string
         default: "Dockerfile"
@@ -86,6 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docker_tag: ${{ steps.set-tag.outputs.tag }}
+      platforms: ${{ steps.set-platforms.outputs.matrix }}
     steps:
       - name: Checkout Project
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -110,6 +120,21 @@ jobs:
             echo "tag=$(git rev-parse --short "$COMMIT_HASH")" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set Build Platforms
+        id: set-platforms
+        env:
+          RUNS_ON_AMD: ${{ inputs.runs-on-amd }}
+          RUNS_ON_ARM: ${{ inputs.runs-on-arm }}
+          BUILD_ARM: ${{ inputs.build-arm }}
+        run: |
+          AMD="{\"platform\":\"linux/amd64\",\"runs-on\":\"$RUNS_ON_AMD\",\"platform-tag\":\"amd64\",\"docker-target\":\"prod\"}"
+          ARM="{\"platform\":\"linux/arm64\",\"runs-on\":\"$RUNS_ON_ARM\",\"platform-tag\":\"arm64\",\"docker-target\":\"prod\"}"
+          if [ "$BUILD_ARM" = "true" ]; then
+            echo "matrix=[$AMD,$ARM]" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=[$AMD]" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-push-docker:
     permissions:
       contents: "read"
@@ -120,13 +145,11 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
       image-amd64-prod: ${{ steps.export-image-and-digest.outputs.image-amd64-prod }}
       digest-amd64-prod: ${{ steps.export-image-and-digest.outputs.digest-amd64-prod }}
+      image-arm64-prod: ${{ steps.export-image-and-digest.outputs.image-arm64-prod }}
+      digest-arm64-prod: ${{ steps.export-image-and-digest.outputs.digest-arm64-prod }}
     strategy:
       matrix:
-        include:
-          - platform: linux/amd64
-            runs-on: ${{ inputs.runs-on-amd }}
-            platform-tag: amd64
-            docker-target: prod
+        include: ${{ fromJSON(needs.determine-tag.outputs.platforms) }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout Project
@@ -242,8 +265,16 @@ jobs:
         id: export-image-and-digest
         if: matrix.docker-target == 'prod'
         run: |
-          echo "image-amd64-prod=${{ steps.push.outputs.image }}" >> $GITHUB_OUTPUT
-          echo "digest-amd64-prod=${{ steps.push.outputs.digest }}" >> $GITHUB_OUTPUT
+          if ${{ matrix.platform-tag == 'amd64' }}
+          then
+            echo "image-amd64-prod=${{ steps.push.outputs.image }}" >> $GITHUB_OUTPUT
+            echo "digest-amd64-prod=${{ steps.push.outputs.digest }}" >> $GITHUB_OUTPUT
+          fi
+          if ${{ matrix.platform-tag == 'arm64' }}
+          then
+            echo "image-arm64-prod=${{ steps.push.outputs.image }}" >> $GITHUB_OUTPUT
+            echo "digest-arm64-prod=${{ steps.push.outputs.digest }}" >> $GITHUB_OUTPUT
+          fi
 
   create-manifest:
     permissions:
@@ -270,13 +301,20 @@ jobs:
         uses: zama-ai/ci-templates/.github/actions/retry@386b427a48c105df7615cc03ad0e3330cedc05d8 # v1.0.8
         with:
           command: |
+            AMEND_ARM=""
+            if [ "${{ inputs.build-arm }}" = "true" ]; then
+              AMEND_ARM="--amend ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }}-arm64-prod"
+            fi
+
             docker manifest create \
               ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }} \
-              --amend ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }}-amd64-prod
+              --amend ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }}-amd64-prod \
+              $AMEND_ARM
 
             docker manifest create \
               ghcr.io/zama-ai/${{ inputs.image-name }}:latest \
-              --amend ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }}-amd64-prod
+              --amend ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }}-amd64-prod \
+              $AMEND_ARM
 
             docker manifest push ghcr.io/zama-ai/${{ inputs.image-name }}:${{ needs.determine-tag.outputs.docker_tag }}
             if [ "${{ github.event_name }}" = "release" ]; then


### PR DESCRIPTION
> **Draft for discussion.** #34 removed arm64 publishing org-wide. Two weeks later the breakage was hit and diagnosed in Slack ([thread](https://zama-ai.slack.com/archives/C065F16D5U3/p1784886921670919)), and the preferred fix was stated there but never implemented — the thread ended on vacation handover. This PR implements that stated fix.

## Context

After #34, `gci/rust-glibc:1.97.1` (the first tag published post-removal) has no arm64 manifest, so any from-source build on Apple-silicon fails at `FROM` with `no match for platform in manifest` — hit and reported on July 24. From the thread:

- *"probably we were fast on removing arm64 for all images, especially base images"*
- *"[the fix] is [publishing the base image]. But the main problem is we use a template for all docker build and **i don't want to switch back all builds with ARM. I'd like to only build and push this specific rust base image.**"*

Meanwhile `zama-ai/fhevm` grew a ~180-line workaround (`solana/scripts/e2e/clean-e2e.sh`) that builds the base natively and temporarily retags the published image name during compose builds. It already prefers a published arm64 manifest when one exists, so it self-neutralizes the moment this lands and a multi-arch tag is published.

## What this does

Exactly the per-image shape described in the thread — **not** an org-wide arm restore:

- New `build-arm` boolean input, **default `false`** — every existing caller keeps building amd64-only, byte-identical behavior, no new runners spawned (the platform matrix is computed in `determine-tag`, so the arm job never starts unless asked for).
- With `build-arm: true`: the `linux/arm64`/prod leg builds on `runs-on-arm` (default `large_ubuntu_16_arm`), and the manifest step amends the arm64 digest into `:tag` and `:latest`.
- Dev images stay removed; the prod-only simplifications from #34 are untouched.

zizmor: medium/high counts identical to main (8/12); +2 informational on the restored lines, same class as their amd64 twins.

## Follow-ups if this lands

1. Tag a release (callers pin by SHA/tag).
2. `zama-ai/fhevm`: pass `build-arm: true` in `golden-container-images-docker-build-rust.yml` and republish `rust-glibc:1.97.1` (or next bump) multi-arch.
3. Delete the fhevm workaround block.

Open question for the owners: does the `large_ubuntu_16_arm` runner label still exist/have capacity? If it was decommissioned with #34, the default needs updating before (2).
